### PR TITLE
scsi: sg: init open_rel_lock mutex

### DIFF
--- a/drivers/scsi/sg.c
+++ b/drivers/scsi/sg.c
@@ -1420,6 +1420,7 @@ static Sg_device *sg_alloc(struct gendisk *disk, struct scsi_device *scsidp)
 	sdp->sg_tablesize = queue_max_segments(q);
 	sdp->index = k;
 	kref_init(&sdp->d_ref);
+	mutex_init(&sdp->open_rel_lock);
 
 	write_unlock_irqrestore(&sg_index_lock, iflags);
 


### PR DESCRIPTION
Commit eeacb548aad15f900edffa6218c7e0e749eac8c3 left it uninitialized.

Change-Id: I931158cb0d766350be26ad82cd98d0010113d895
Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>